### PR TITLE
fix: extract semver version from release tag in publish-chart

### DIFF
--- a/.github/workflows/publish-chart.yaml
+++ b/.github/workflows/publish-chart.yaml
@@ -24,11 +24,14 @@ jobs:
       - name: Extract version from release tag
         id: version
         run: |
+          # Extract version from tag (format: spicedb-1.0.0 or spicedb-v1.0.0)
+          TAG="${{ github.event.release.tag_name }}"
+          # Remove chart name prefix (spicedb-)
+          VERSION="${TAG#spicedb-}"
           # Remove 'v' prefix if present
-          VERSION="${{ github.event.release.tag_name }}"
           VERSION="${VERSION#v}"
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
-          echo "Extracted version: ${VERSION}"
+          echo "Extracted version from tag '${TAG}': ${VERSION}"
 
       - name: Update Chart version
         run: |


### PR DESCRIPTION
## Problem

The publish-chart workflow failed with:
```
Error: validation: chart.metadata.version "spicedb-1.1.0" is invalid
```

The release tag format is `spicedb-1.1.0`, but Helm Chart.yaml requires strict semver format `1.1.0`.

## Root Cause

The version extraction step was only removing the `v` prefix, not the chart name prefix.

## Solution

Strip both the chart name prefix and optional `v` prefix to get clean semver version.

## Examples

| Release Tag | Extracted Version |
|-------------|------------------|
| `spicedb-1.1.0` | `1.1.0` ✅ |
| `spicedb-v1.1.0` | `1.1.0` ✅ |

## Testing

After merging, we can re-run the failed publish workflow or wait for the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>