### PR TITLE
fix: resolve race condition in PostgreSQL deployment wait

### DIFF
--- a/charts/spicedb/tests/integration/migration-test.sh
+++ b/charts/spicedb/tests/integration/migration-test.sh
@@ -125,8 +125,8 @@ deploy_postgres() {
     kubectl apply -f "$SCRIPT_DIR/postgres-deployment.yaml"
 
     log_info "Waiting for PostgreSQL StatefulSet to be ready..."
-    kubectl wait --for=condition=ready pod \
-        -l "app.kubernetes.io/name=postgres" \
+    kubectl wait --for=jsonpath='{.status.readyReplicas}'=1 \
+        statefulset/postgres \
         -n "$NAMESPACE" \
         --timeout=300s
 


### PR DESCRIPTION
## Problem

Integration tests are failing intermittently after release 1.1.1 with the error:
```
[INFO] Waiting for PostgreSQL StatefulSet to be ready...
error: no matching resources found
```

This is a **race condition** in the PostgreSQL deployment wait logic.

## Root Cause

When `kubectl wait --for=condition=ready pod -l "selector"` is executed and **no pods exist yet**, it fails immediately with "no matching resources found" instead of waiting for pods to appear.

**Timeline from failed run (v1.28.0):**
```
16:34:42.27 - statefulset.apps/postgres created
16:34:42.27 - service/postgres created
16:34:42.27 - [INFO] Waiting for PostgreSQL StatefulSet to be ready...
16:34:42.32 - error: no matching resources found  (0.05 seconds later!)
```

**Timeline from successful run (for comparison):**
```
05:55:05.80 - statefulset.apps/postgres created
05:55:05.81 - [INFO] Waiting for PostgreSQL StatefulSet to be ready...
05:55:20.20 - pod/postgres-0 condition met  (15 seconds later)
```

The difference: In the failed run, `kubectl wait` ran before the StatefulSet controller created any pods. The typical delay for pod creation is 50-500ms, but depends on runner performance.

## Solution

Wait for the StatefulSet's `readyReplicas` status instead of waiting for pods directly:

```bash
kubectl wait --for=jsonpath='{.status.readyReplicas}'=1 \
    statefulset/postgres \
    -n "$NAMESPACE" \
    --timeout=300s
```

**Why this works:**
- The StatefulSet resource exists immediately after `kubectl apply`
- `readyReplicas` is updated by the StatefulSet controller when pods are ready
- No race condition since we're waiting on the StatefulSet itself, not pods
- More direct and follows Kubernetes best practices

## Impact

- ✅ Fixes intermittent failures on all K8s versions (v1.28.0, v1.29.0, v1.30.0)
- ✅ More reliable deployment verification
- ✅ Follows Kubernetes best practices for StatefulSet monitoring
- ✅ Same functional outcome, more robust implementation

## Testing

The integration tests in this PR will verify the fix works across all K8s versions in the test matrix.

## Related

This race condition has existed since integration tests were introduced but only manifested intermittently based on GitHub Actions runner performance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)