### PR TITLE
fix(docs): correct CI badge workflow reference in SpiceDB README

### DIFF
--- a/charts/spicedb/README.md
+++ b/charts/spicedb/README.md
@@ -1,6 +1,6 @@
 # SpiceDB Helm Chart
 
-[![Helm Chart CI](https://github.com/salekseev/helm-charts/actions/workflows/ci.yaml/badge.svg)](https://github.com/salekseev/helm-charts/actions/workflows/ci.yaml)
+[![Helm Chart CI](https://github.com/salekseev/helm-charts/actions/workflows/ci-unit.yaml/badge.svg)](https://github.com/salekseev/helm-charts/actions/workflows/ci-unit.yaml)
 
 Production-ready Helm chart for deploying [SpiceDB](https://authzed.com/spicedb) - an open source, Google Zanzibar-inspired permissions database for fine-grained authorization at scale.
 


### PR DESCRIPTION
## Summary
- Fixed broken CI badge in SpiceDB chart README
- Badge was referencing non-existent `ci.yaml` workflow
- Updated to point to actual `ci-unit.yaml` workflow

## Changes
- `charts/spicedb/README.md`: Updated badge URL from `workflows/ci.yaml` to `workflows/ci-unit.yaml`

## Verification
The badge will now correctly display the status of the unit test workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)